### PR TITLE
Add project-in-run check Lambda to autoController and fail states to autoPackagePush.

### DIFF
--- a/app/lambdas/check_project_in_instrument_run_py/check_project_in_instrument_run.py
+++ b/app/lambdas/check_project_in_instrument_run_py/check_project_in_instrument_run.py
@@ -24,8 +24,8 @@ def handler(event, context):
     instrument_run_id = event["instrumentRunId"]
     project_ids_in_run = get_all_project_ids_in_an_instrument_run(instrument_run_id)
 
-    intersection = set(project_id_list) & set(project_ids_in_run)
-    project_found = True if intersection else False
+    intersection = set(project_id_list).intersection(project_ids_in_run)
+    project_found = len(intersection) > 0
 
     return {
         "project_found": project_found

--- a/app/lambdas/check_project_in_instrument_run_py/check_project_in_instrument_run.py
+++ b/app/lambdas/check_project_in_instrument_run_py/check_project_in_instrument_run.py
@@ -24,7 +24,8 @@ def handler(event, context):
     instrument_run_id = event["instrumentRunId"]
     project_ids_in_run = get_all_project_ids_in_an_instrument_run(instrument_run_id)
 
-    project_found = bool(set(event["projectIdList"]) & set(project_ids_in_run))
+    intersection = set(project_id_list) & set(project_ids_in_run)
+    project_found = True if intersection else False
 
     return {
         "project_found": project_found

--- a/app/lambdas/check_project_in_instrument_run_py/check_project_in_instrument_run.py
+++ b/app/lambdas/check_project_in_instrument_run_py/check_project_in_instrument_run.py
@@ -21,8 +21,7 @@ def handler(event, context):
     Check if any requested projects are found in the specified instrument run.
     """
     project_ids_in_job = event["projectIdList"]
-    instrument_run_id = event["instrumentRunId"]
-    project_ids_in_run = get_all_project_ids_in_an_instrument_run(instrument_run_id)
+    project_ids_in_run = get_all_project_ids_in_an_instrument_run(event["instrumentRunId"])
 
     project_ids_in_run_filtered = set(project_ids_in_job).intersection(project_ids_in_run)
     project_found = len(project_ids_in_run_filtered) > 0

--- a/app/lambdas/check_project_in_instrument_run_py/check_project_in_instrument_run.py
+++ b/app/lambdas/check_project_in_instrument_run_py/check_project_in_instrument_run.py
@@ -20,12 +20,12 @@ def handler(event, context):
     """
     Check if any requested projects are found in the specified instrument run.
     """
-    project_id_list = event["projectIdList"]
+    project_ids_in_job = event["projectIdList"]
     instrument_run_id = event["instrumentRunId"]
     project_ids_in_run = get_all_project_ids_in_an_instrument_run(instrument_run_id)
 
-    intersection = set(project_id_list).intersection(project_ids_in_run)
-    project_found = len(intersection) > 0
+    project_ids_in_run_filtered = set(project_ids_in_job).intersection(project_ids_in_run)
+    project_found = len(project_ids_in_run_filtered) > 0
 
     return {
         "project_found": project_found

--- a/app/lambdas/check_project_in_instrument_run_py/check_project_in_instrument_run.py
+++ b/app/lambdas/check_project_in_instrument_run_py/check_project_in_instrument_run.py
@@ -1,0 +1,31 @@
+
+from orcabus_api_tools.sequence import get_libraries_from_instrument_run_id
+from orcabus_api_tools.metadata import get_library_from_library_id
+
+def get_all_project_ids_in_an_instrument_run(instrument_run_id):
+    """
+    Retrieve all unique project IDs associated with all the libraries in a given instrument run.
+    """
+    lib_ids = get_libraries_from_instrument_run_id(instrument_run_id)
+
+    project_ids = set()
+    for lib_id in lib_ids:
+        library = get_library_from_library_id(lib_id)
+        for project in library["projectSet"]:
+            project_ids.add(project["projectId"])
+
+    return list(project_ids)
+
+def handler(event, context):
+    """
+    Check if any requested projects are found in the specified instrument run.
+    """
+    project_id_list = event["projectIdList"]
+    instrument_run_id = event["instrumentRunId"]
+    project_ids_in_run = get_all_project_ids_in_an_instrument_run(instrument_run_id)
+
+    project_found = bool(set(event["projectIdList"]) & set(project_ids_in_run))
+
+    return {
+        "project_found": project_found
+    }

--- a/app/step-functions-templates/auto_controller_sfn_template.asl.json
+++ b/app/step-functions-templates/auto_controller_sfn_template.asl.json
@@ -30,24 +30,51 @@
           "Mode": "DISTRIBUTED",
           "ExecutionType": "STANDARD"
         },
-        "StartAt": "Check enabled",
+        "StartAt": "Check projects in instrument run",
         "States": {
-          "Check enabled": {
+          "Check projects in instrument run": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "Arguments": {
+              "FunctionName": "${__check_project_in_instrument_run_lambda_function_arn__}",
+              "Payload": {
+                "instrumentRunId": "{% $states.input.packageRequest.instrumentRunIdList[0] %}",
+                "projectIdList": "{% $states.input.packageRequest.projectIdList %}"
+              }
+            },
+            "Retry": [
+              {
+                "ErrorEquals": [
+                  "Lambda.ServiceException",
+                  "Lambda.AWSLambdaException",
+                  "Lambda.SdkClientException",
+                  "Lambda.TooManyRequestsException"
+                ],
+                "IntervalSeconds": 1,
+                "MaxAttempts": 3,
+                "BackoffRate": 2,
+                "JitterStrategy": "FULL"
+              }
+            ],
+            "Output": "{% $merge([$states.input, $states.result.Payload]) %}",
+            "Next": "Job Enabled and Project Found in Run?"
+          },
+          "Job Enabled and Project Found in Run?": {
             "Type": "Choice",
             "Choices": [
               {
-                "Condition": "{% $states.input.enabled = true %}",
+                "Condition": "{% $states.input.enabled and $states.input.project_found %}",
                 "Next": "Run autoPackagePush"
               }
             ],
-            "Default": "Skip (disabled)"
+            "Default": "Skip"
           },
           "Run autoPackagePush": {
             "Type": "Task",
             "Resource": "arn:aws:states:::states:startExecution.sync:2",
             "Arguments": {
               "StateMachineArn": "${__auto_package_push_sfn_arn__}",
-              "Input": "{% $states.input %}"
+              "Input": "{% { 'packageName': $states.input.packageName, 'packageRequest': $states.input.packageRequest, 'shareDestination': $states.input.shareDestination } %}"
             },
             "Retry": [
               {
@@ -60,7 +87,7 @@
             ],
             "End": true
           },
-          "Skip (disabled)": {
+          "Skip": {
             "Type": "Succeed"
           }
         }

--- a/app/step-functions-templates/auto_controller_sfn_template.asl.json
+++ b/app/step-functions-templates/auto_controller_sfn_template.asl.json
@@ -45,6 +45,7 @@
             "Retry": [
               {
                 "ErrorEquals": [
+                  "States.TaskFailed",
                   "Lambda.ServiceException",
                   "Lambda.AWSLambdaException",
                   "Lambda.SdkClientException",
@@ -74,7 +75,11 @@
             "Resource": "arn:aws:states:::states:startExecution.sync:2",
             "Arguments": {
               "StateMachineArn": "${__auto_package_push_sfn_arn__}",
-              "Input": "{% { 'packageName': $states.input.packageName, 'packageRequest': $states.input.packageRequest, 'shareDestination': $states.input.shareDestination } %}"
+              "Input": {
+                "packageName": "{% $states.input.packageName %}",
+                "packageRequest": "{% $states.input.packageRequest %}",
+                "shareDestination": "{% $states.input.shareDestination %}"
+              }
             },
             "Retry": [
               {

--- a/app/step-functions-templates/auto_package_push_sfn_template.asl.json
+++ b/app/step-functions-templates/auto_package_push_sfn_template.asl.json
@@ -64,6 +64,10 @@
         {
           "Condition": "{% $states.input.status = 'SUCCEEDED' %}",
           "Next": "Trigger Push"
+        },
+        {
+          "Condition": "{% $states.input.status = 'FAILED' or $states.input.status = 'CANCELLED' %}",
+          "Next": "Auto Package-Push Failed"
         }
       ],
       "Default": "Wait For Package"
@@ -129,12 +133,19 @@
         {
           "Condition": "{% $states.input.status = 'SUCCEEDED' %}",
           "Next": "Auto Package-Push Complete"
+        },
+        {
+          "Condition": "{% $states.input.status = 'FAILED' or $states.input.status = 'CANCELLED' %}",
+          "Next": "Auto Package-Push Failed"
         }
       ],
       "Default": "Wait For Push"
     },
     "Auto Package-Push Complete": {
       "Type": "Succeed"
+    },
+    "Auto Package-Push Failed": {
+      "Type": "Fail"
     }
   }
 }

--- a/app/step-functions-templates/auto_package_push_sfn_template.asl.json
+++ b/app/step-functions-templates/auto_package_push_sfn_template.asl.json
@@ -66,7 +66,7 @@
           "Next": "Trigger Push"
         },
         {
-          "Condition": "{% $states.input.status = 'FAILED' or $states.input.status = 'CANCELLED' %}",
+          "Condition": "{% $states.input.status in [ 'FAILED', 'CANCELLED' ] %}",
           "Next": "Auto Package-Push Failed"
         }
       ],
@@ -135,7 +135,7 @@
           "Next": "Auto Package-Push Complete"
         },
         {
-          "Condition": "{% $states.input.status = 'FAILED' or $states.input.status = 'CANCELLED' %}",
+          "Condition": "{% $states.input.status in [ 'FAILED', 'CANCELLED' ] %}",
           "Next": "Auto Package-Push Failed"
         }
       ],

--- a/infrastructure/stage/lambdas/interfaces.ts
+++ b/infrastructure/stage/lambdas/interfaces.ts
@@ -26,7 +26,8 @@ export type LambdaName =
   | 'getDynamodbEvaluatedKeyList'
   | 'triggerPackaging'
   | 'checkPackagePushStatus'
-  | 'triggerPush';
+  | 'triggerPush'
+  | 'checkProjectInInstrumentRun';
 
 export const lambdaNameList: LambdaName[] = [
   'createCsvForS3StepsCopy',
@@ -52,6 +53,7 @@ export const lambdaNameList: LambdaName[] = [
   'triggerPackaging',
   'checkPackagePushStatus',
   'triggerPush',
+  'checkProjectInInstrumentRun',
 ];
 
 export interface Requirements {
@@ -149,6 +151,9 @@ export const lambdaRequirementsMap: { [key in LambdaName]: Requirements } = {
     needsOrcabusApiToolsLayer: true,
   },
   triggerPush: {
+    needsOrcabusApiToolsLayer: true,
+  },
+  checkProjectInInstrumentRun: {
     needsOrcabusApiToolsLayer: true,
   },
 };

--- a/infrastructure/stage/step-functions/interfaces.ts
+++ b/infrastructure/stage/step-functions/interfaces.ts
@@ -52,7 +52,7 @@ export const lambdasInStepFunctions: Record<StepFunctionsName, LambdaName[]> = {
   ],
   push: ['updatePushJobApi', 'uploadPushJobToS3'],
   autoPackagePush: ['triggerPackaging', 'triggerPush', 'checkPackagePushStatus'],
-  autoController: [],
+  autoController: ['checkProjectInInstrumentRun'],
 };
 
 export interface StepFunctionRequirements {


### PR DESCRIPTION
Adds the `check_project_in_instrument_run` Lambda and integrates it into the auto_controller Step Function to verify project presence before triggering autoPackagePush.
Also updates `auto_package_push_sfn_template.asl.json` to include explicit Fail states for package and push steps, preventing the state machine from getting stuck in the loop waiting for a `SUCCEEDED` status.