### PR TITLE
Previously looked at all s3 objects, now only look at those with current state

### DIFF
--- a/app/lambdas/get_files_and_relative_paths_from_s3_attribute_ids_py/get_files_and_relative_paths_from_s3_attribute_ids.py
+++ b/app/lambdas/get_files_and_relative_paths_from_s3_attribute_ids_py/get_files_and_relative_paths_from_s3_attribute_ids.py
@@ -50,7 +50,9 @@ def handler(event, context) -> Dict[str, List['FileObjectWithRelativePathTypeDef
     # Check at least one of 's3ObjectId' or 'ingestId' is in the event
     file_object_list: List['FileObject'] = list(map(
         lambda ingest_file_iter_: ingest_file_iter_.get('fileObject'),
-        get_s3_objs_from_ingest_ids_map(event.get('ingestIdList'), currentState="false")
+        get_s3_objs_from_ingest_ids_map(
+            ingest_ids=event.get('ingestIdList')
+        )
     ))
 
     # Get the data type


### PR DESCRIPTION
Some non-current state objects will not have a storage class object to compare to anyway