### PR TITLE
Update separator between stack prefix and sfn name

### DIFF
--- a/infrastructure/stage/step-functions/index.ts
+++ b/infrastructure/stage/step-functions/index.ts
@@ -103,22 +103,22 @@ function createStateMachineDefinitionSubstitutions(props: SfnProps): {
     switch (nestedSfnName) {
       case 'pushS3Data': {
         definitionSubstitutions['__push_s3_data_sfn_arn__'] =
-          `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:${STACK_PREFIX}-${nestedSfnName}`;
+          `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:${STACK_PREFIX}--${nestedSfnName}`;
         break;
       }
       case 'pushIcav2Data': {
         definitionSubstitutions['__icav2_data_push_sfn_arn__'] =
-          `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:${STACK_PREFIX}-${nestedSfnName}`;
+          `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:${STACK_PREFIX}--${nestedSfnName}`;
         break;
       }
       case autoPackageSfnName: {
         definitionSubstitutions['__auto_package_sfn_arn__'] =
-          `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:${STACK_PREFIX}-${nestedSfnName}`;
+          `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:${STACK_PREFIX}--${nestedSfnName}`;
         break;
       }
       case updateFastqIngestIdsSfnName: {
         definitionSubstitutions['__update_fastq_ingest_ids_sfn_arn__'] =
-          `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:${STACK_PREFIX}-${nestedSfnName}`;
+          `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:${STACK_PREFIX}--${nestedSfnName}`;
         break;
       }
     }
@@ -281,8 +281,8 @@ function wireUpStateMachinePermissions(scope: Construct, props: SfnPropsWithStat
               new iam.PolicyStatement({
                 actions: ['states:StartExecution', 'states:DescribeExecution'],
                 resources: [
-                  `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:${STACK_PREFIX}-${nestedSfnName}`,
-                  `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:execution:${STACK_PREFIX}-${nestedSfnName}:*`,
+                  `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:${STACK_PREFIX}--${nestedSfnName}`,
+                  `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:execution:${STACK_PREFIX}--${nestedSfnName}:*`,
                 ],
               })
             );
@@ -298,8 +298,8 @@ function wireUpStateMachinePermissions(scope: Construct, props: SfnPropsWithStat
         new iam.PolicyStatement({
           actions: ['states:StartExecution', 'states:DescribeExecution'],
           resources: [
-            `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:${STACK_PREFIX}-${autoPackageSfnName}`,
-            `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:execution:${STACK_PREFIX}-${autoPackageSfnName}:*`,
+            `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:${STACK_PREFIX}--${autoPackageSfnName}`,
+            `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:execution:${STACK_PREFIX}--${autoPackageSfnName}:*`,
           ],
         })
       );
@@ -313,8 +313,8 @@ function wireUpStateMachinePermissions(scope: Construct, props: SfnPropsWithStat
         new iam.PolicyStatement({
           actions: ['states:StartExecution', 'states:DescribeExecution'],
           resources: [
-            `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:${STACK_PREFIX}-${updateFastqIngestIdsSfnName}`,
-            `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:execution:${STACK_PREFIX}-${updateFastqIngestIdsSfnName}:*`,
+            `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:${STACK_PREFIX}--${updateFastqIngestIdsSfnName}`,
+            `arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:execution:${STACK_PREFIX}--${updateFastqIngestIdsSfnName}:*`,
           ],
         })
       );
@@ -378,7 +378,7 @@ function buildStepFunction(scope: Construct, props: SfnProps): SfnObject {
 
   /* Create the state machine definition substitutions */
   const stateMachine = new sfn.StateMachine(scope, props.stateMachineName, {
-    stateMachineName: `${STACK_PREFIX}-${props.stateMachineName}`,
+    stateMachineName: `${STACK_PREFIX}--${props.stateMachineName}`,
     definitionBody: sfn.DefinitionBody.fromFile(
       path.join(STEP_FUNCTIONS_DIR, sfnNameToSnakeCase + `_sfn_template.asl.json`)
     ),


### PR DESCRIPTION
Harmonise across orcabus sfn services to use double hyphen to separate stack name and step function name