### PR TITLE
Override transitive diff to >=8.0.3 to fix security advisory.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,10 @@
     "@orcabus/platform-cdk-constructs": "0.0.86",
     "aws-cdk-lib": "^2.225.0",
     "constructs": "^10.4.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "diff": ">=8.0.3"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  diff: '>=8.0.3'
+
 importers:
 
   .:
@@ -779,8 +782,8 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
   electron-to-chromium@1.5.255:
@@ -2568,7 +2571,7 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  diff@4.0.2: {}
+  diff@8.0.3: {}
 
   electron-to-chromium@1.5.255: {}
 
@@ -3502,7 +3505,7 @@ snapshots:
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.2
+      diff: 8.0.3
       make-error: 1.3.6
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1


### PR DESCRIPTION

`make check `started failing due to a [newly published security advisory](https://github.com/advisories/GHSA-73rr-hh4g-fpgx?utm_source=chatgpt.com) affecting the transitive dependency diff (pulled in via ts-node).


```
 make check
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ low                 │ jsdiff has a Denial of Service vulnerability in        │
│                     │ parsePatch and applyPatch                              │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ diff                                                   │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <8.0.3                                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=8.0.3                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>ts-node>diff                                         │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-73rr-hh4g-fpgx      │
└─────────────────────┴────────────────────────────────────────────────────────┘
1 vulnerabilities found
Severity: 1 low
make: *** [check] Error 1
```


**Change**

- Added a pnpm override to force `diff >= 8.0.3 `across the dependency tree.

- Regenerated `pnpm-lock.yaml`.