### PR TITLE
Configures 1GB memory for PyArrow/Pandas Lambdas

### DIFF
--- a/infrastructure/stage/lambdas/index.ts
+++ b/infrastructure/stage/lambdas/index.ts
@@ -44,6 +44,7 @@ function buildLambdaFunction(scope: Construct, props: LambdaProps): LambdaObject
     timeout: Duration.seconds(300),
     includeOrcabusApiToolsLayer: lambdaRequirements.needsOrcabusApiToolsLayer,
     includeMartLayer: lambdaRequirements.needsMartLayer,
+    memorySize: lambdaRequirements.needsHigherMemory ? 1024 : undefined,
   });
 
   if (lambdaRequirements.needsDataSharingToolsLayer) {

--- a/infrastructure/stage/lambdas/index.ts
+++ b/infrastructure/stage/lambdas/index.ts
@@ -44,7 +44,7 @@ function buildLambdaFunction(scope: Construct, props: LambdaProps): LambdaObject
     timeout: Duration.seconds(300),
     includeOrcabusApiToolsLayer: lambdaRequirements.needsOrcabusApiToolsLayer,
     includeMartLayer: lambdaRequirements.needsMartLayer,
-    memorySize: lambdaRequirements.needsHigherMemory ? 1024 : undefined,
+    ...(lambdaRequirements.needsHigherMemory ? { memorySize: 1024 } : {}),
   });
 
   if (lambdaRequirements.needsDataSharingToolsLayer) {

--- a/infrastructure/stage/lambdas/interfaces.ts
+++ b/infrastructure/stage/lambdas/interfaces.ts
@@ -78,6 +78,7 @@ export interface Requirements {
   needsStepsS3UploadPermissions?: boolean;
   needsStepsS3DownloadPermissions?: boolean;
   needsPackagingBucketPermissions?: boolean;
+  needsHigherMemory?: boolean;
 }
 
 export const lambdaRequirementsMap: { [key in LambdaName]: Requirements } = {
@@ -111,10 +112,12 @@ export const lambdaRequirementsMap: { [key in LambdaName]: Requirements } = {
     needsDataSharingToolsLayer: true,
     needsOrcabusApiToolsLayer: true,
     needsDbPermissions: true,
+    needsHigherMemory: true,
   },
   getWorkflowFromPortalRunId: {
     needsOrcabusApiToolsLayer: true,
     needsMartLayer: true,
+    needsHigherMemory: true,
   },
   handleWorkflowInputs: {
     needsOrcabusApiToolsLayer: true,
@@ -132,18 +135,22 @@ export const lambdaRequirementsMap: { [key in LambdaName]: Requirements } = {
     needsOrcabusApiToolsLayer: true,
     needsDataSharingToolsLayer: true,
     needsDbPermissions: true,
+    needsHigherMemory: true,
   },
   listPortalRunIdsInLibrary: {
     needsOrcabusApiToolsLayer: true,
+    needsHigherMemory: true,
   },
   packageFileToJsonlData: {
     needsDbPermissions: true,
     needsStepsS3UploadPermissions: true,
     needsDataSharingToolsLayer: true,
     needsOrcabusApiToolsLayer: true,
+    needsHigherMemory: true,
   },
   checkStepsCopyOutput: {
     needsStepsS3DownloadPermissions: true,
+    needsHigherMemory: true,
   },
   updatePackagingJobApi: {
     needsOrcabusApiToolsLayer: true,
@@ -154,12 +161,14 @@ export const lambdaRequirementsMap: { [key in LambdaName]: Requirements } = {
   uploadArchiveFileListAsCsv: {
     needsDataSharingToolsLayer: true,
     needsOrcabusApiToolsLayer: true,
+    needsHigherMemory: true,
   },
   uploadPushJobToS3: {
     needsDbPermissions: true,
     needsDataSharingToolsLayer: true,
     needsPackagingBucketPermissions: true,
     needsOrcabusApiToolsLayer: true,
+    needsHigherMemory: true,
   },
   getDynamodbEvaluatedKeyList: {
     needsDbPermissions: true,
@@ -186,6 +195,7 @@ export const lambdaRequirementsMap: { [key in LambdaName]: Requirements } = {
     needsDataSharingToolsLayer: true,
     needsOrcabusApiToolsLayer: true,
     needsDbPermissions: true,
+    needsHigherMemory: true,
   },
   extractSlackActionContext: {},
   verifySlackRequest: {},


### PR DESCRIPTION
Allocates 1024MB (1GB) of memory to Lambdas that utilize memory-intensive libraries such as PyArrow and Pandas. This change introduces a `needsHigherMemory` flag, which, when set, ensures these specific functions have adequate resources to execute efficiently and reliably.