### PR TITLE
Fix/find matching jobs/serialization error

### DIFF
--- a/app/lambdas/find_matching_jobs_for_run_py/find_matching_jobs_for_run.py
+++ b/app/lambdas/find_matching_jobs_for_run_py/find_matching_jobs_for_run.py
@@ -92,7 +92,7 @@ def handler(event, context):
             "packageName": merged_df_group_iter_['jobName'].unique().item(),
             "packageRequest": {
                 "libraryIdList": merged_df_group_iter_['libraryId'].tolist(),
-                "dataTypeList": merged_df_group_iter_["dataTypeList"],
+                "dataTypeList": merged_df_group_iter_["dataTypeList"].tolist(),
                 "instrumentRunIdList": [instrument_run_id],
             },
         }

--- a/app/lambdas/find_matching_jobs_for_run_py/find_matching_jobs_for_run.py
+++ b/app/lambdas/find_matching_jobs_for_run_py/find_matching_jobs_for_run.py
@@ -89,7 +89,7 @@ def handler(event, context):
 
     job_list = [
         {
-            "packageName": merged_df_group_iter_['jobName'].unique().item()+"-"+instrument_run_id,
+            "packageName": f"{merged_df_group_iter_['jobName'].unique().item()}-{instrument_run_id}",
             "packageRequest": {
                 "libraryIdList": merged_df_group_iter_['libraryId'].tolist(),
                 "dataTypeList": merged_df_group_iter_["dataTypeList"].tolist(),

--- a/app/lambdas/find_matching_jobs_for_run_py/find_matching_jobs_for_run.py
+++ b/app/lambdas/find_matching_jobs_for_run_py/find_matching_jobs_for_run.py
@@ -89,7 +89,7 @@ def handler(event, context):
 
     job_list = [
         {
-            "packageName": merged_df_group_iter_['jobName'].unique().item(),
+            "packageName": merged_df_group_iter_['jobName'].unique().item()+"-"+instrument_run_id,
             "packageRequest": {
                 "libraryIdList": merged_df_group_iter_['libraryId'].tolist(),
                 "dataTypeList": merged_df_group_iter_["dataTypeList"].tolist(),


### PR DESCRIPTION
This PR fixes the error in `find_matching_jobs_for_run` lambda (`"Unable to marshal response: Object of type Series is not JSON serializable"`) by converting `dataTypeList` from a pandas Series to a plain list before returning it. It also updates `packageName` to include the `instrumentRunId`.