### PR TITLE
Use variable assignments in auto push

### DIFF
--- a/app/lambdas/check_package_push_status_py/check_package_push_status.py
+++ b/app/lambdas/check_package_push_status_py/check_package_push_status.py
@@ -19,4 +19,6 @@ def handler(event, context=None):
     if job_id.startswith(("pkg.")):
         status = get_package(job_id)["status"]
 
-    return status
+    return {
+        "status": status
+    }

--- a/app/lambdas/notify_slack_py/notify_slack.py
+++ b/app/lambdas/notify_slack_py/notify_slack.py
@@ -298,7 +298,7 @@ def handler(event, context):
 
     # Push result context
     # Used in: PUSH_COMPLETED
-    status = event.get("status")
+    push_status = event.get("pushStatus")
     push_id = event.get("pushId")
 
     # Report link
@@ -460,7 +460,7 @@ def handler(event, context):
 
     elif slack_notification_type == "PUSH_COMPLETED":
         # Push succeded
-        if status == "SUCCEEDED":
+        if push_status == "SUCCEEDED":
 
             # Update Status in main messege to "Completed!".
             succeeded_card_blocks = _build_main_message_blocks(job_name, package_name, ':white_check_mark: Completed!')
@@ -474,7 +474,7 @@ def handler(event, context):
 
             # Post message in thread to show the push result and details.
             push_succeeded_text = (
-                f"*Push Completed:* {status}.\n"
+                f"*Push Completed:* {push_status}.\n"
                 f"*Push ID:* {push_id}\n"
                 f"*Share Destination:* `{share_destination}`"
             )
@@ -500,7 +500,7 @@ def handler(event, context):
             )
             # Post message in thread to show the push result and details.
             push_failed_text = (
-                f"*Push completed, but was NOT successful:* {status}\n"
+                f"*Push completed, but was NOT successful:* {push_status}\n"
                 f"*Push ID:* {push_id}\n"
                 f"*Share Destination:* `{share_destination}`\n"
                 f"Please check `data-sharing--autoPush` state machine for more details."

--- a/app/step-functions-templates/auto_package_sfn_template.asl.json
+++ b/app/step-functions-templates/auto_package_sfn_template.asl.json
@@ -75,7 +75,7 @@
       "Next": "Is Package Complete",
       "Output": {},
       "Assign": {
-        "status": "{% $states.result.Payload %}"
+        "status": "{% $states.result.Payload.status %}"
       }
     },
     "Is Package Complete": {

--- a/app/step-functions-templates/auto_push_sfn_template.asl.json
+++ b/app/step-functions-templates/auto_push_sfn_template.asl.json
@@ -1,22 +1,31 @@
 {
   "QueryLanguage": "JSONata",
-  "StartAt": "Verify Slack Request",
+  "StartAt": "Set vars",
   "TimeoutSeconds": 86400,
   "States": {
+    "Set vars": {
+      "Type": "Pass",
+      "Next": "Verify Slack Request",
+      "Assign": {
+        "slackBody": "{% $states.input.slackBody %}",
+        "headers": "{% $states.input.headers %}"
+      },
+      "Output": {}
+    },
     "Verify Slack Request": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Arguments": {
         "FunctionName": "${__verify_slack_request_lambda_function_arn__}",
         "Payload": {
-          "slackBody": "{% $states.input.slackBody %}",
-          "headers": "{% $states.input.headers %}"
+          "slackBody": "{% $slackBody %}",
+          "headers": "{% $headers %}"
         }
       },
-      "Output": {
-        "verified": "{% $states.result.Payload.verified %}",
-        "slackBody": "{% $states.input.slackBody %}"
+      "Assign": {
+        "slackVerified": "{% $states.result.Payload.verified %}"
       },
+      "Output": {},
       "Retry": [
         {
           "ErrorEquals": [
@@ -37,7 +46,7 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Condition": "{% $states.input.verified = false  %}",
+          "Condition": "{% $slackVerified = false  %}",
           "Next": "Slack not Verified"
         }
       ],
@@ -54,19 +63,21 @@
       "Arguments": {
         "FunctionName": "${__extract_slack_action_context_lambda_function_arn__}",
         "Payload": {
-          "slackBody": "{% $states.input.slackBody %}"
+          "slackBody": "{% $slackBody %}"
         }
       },
-      "Output": {
-        "userAllowed": "{% $states.result.Payload.userAllowed %}",
+      "Assign": {
+        "userId": "{% $states.result.Payload.userId %}",
+        "channelId": "{% $states.result.Payload.channelId %}",
         "packageId": "{% $states.result.Payload.packageId %}",
         "packageName": "{% $states.result.Payload.packageName %}",
         "shareDestination": "{% $states.result.Payload.shareDestination %}",
-        "userId": "{% $states.result.Payload.userId %}",
-        "channelId": "{% $states.result.Payload.channelId %}",
         "jobName": "{% $states.result.Payload.jobName %}",
         "packageReadyMessageTs": "{% $states.result.Payload.packageReadyMessageTs %}",
         "mainMessageTs": "{% $states.result.Payload.mainMessageTs %}"
+      },
+      "Output": {
+        "userAllowed": "{% $states.result.Payload.userAllowed %}"
       },
       "Retry": [
         {
@@ -101,26 +112,17 @@
         "FunctionName": "${__notify_slack_lambda_function_arn__}",
         "Payload": {
           "slackNotificationType": "PUSH_TRIGGERED",
-          "jobName": "{% $states.input.jobName %}",
-          "packageId": "{% $states.input.packageId %}",
-          "packageName": "{% $states.input.packageName %}",
-          "shareDestination": "{% $states.input.shareDestination %}",
-          "userId": "{% $states.input.userId %}",
-          "channelId": "{% $states.input.channelId %}",
-          "mainMessageTs": "{% $states.input.mainMessageTs %}",
-          "packageReadyMessageTs": "{% $states.input.packageReadyMessageTs %}"
+          "jobName": "{% $jobName %}",
+          "packageId": "{% $packageId %}",
+          "packageName": "{% $packageName %}",
+          "shareDestination": "{% $shareDestination %}",
+          "userId": "{% $userId %}",
+          "channelId": "{% $channelId %}",
+          "mainMessageTs": "{% $mainMessageTs %}",
+          "packageReadyMessageTs": "{% $packageReadyMessageTs %}"
         }
       },
-      "Output": {
-        "shareDestination": "{% $states.input.shareDestination %}",
-        "jobName": "{% $states.input.jobName %}",
-        "packageId": "{% $states.input.packageId %}",
-        "packageName": "{% $states.input.packageName %}",
-        "userId": "{% $states.input.userId %}",
-        "channelId": "{% $states.input.channelId %}",
-        "mainMessageTs": "{% $states.input.mainMessageTs %}",
-        "packageReadyMessageTs": "{% $states.input.packageReadyMessageTs %}"
-      },
+      "Output": {},
       "Retry": [
         {
           "ErrorEquals": [
@@ -144,9 +146,9 @@
         "FunctionName": "${__notify_slack_lambda_function_arn__}",
         "Payload": {
           "slackNotificationType": "PUSH_NOT_AUTHORISED",
-          "userId": "{% $states.input.userId %}",
-          "channelId": "{% $states.input.channelId %}",
-          "mainMessageTs": "{% $states.input.mainMessageTs %}"
+          "userId": "{% $userId %}",
+          "channelId": "{% $channelId %}",
+          "mainMessageTs": "{% $mainMessageTs %}"
         }
       },
       "Retry": [
@@ -171,21 +173,13 @@
       "Arguments": {
         "FunctionName": "${__trigger_push_lambda_function_arn__}",
         "Payload": {
-          "packageId": "{% $states.input.packageId %}",
-          "shareDestination": "{% $states.input.shareDestination %}"
+          "packageId": "{% $packageId %}",
+          "shareDestination": "{% $shareDestination %}"
         }
       },
       "Output": {
         "id": "{% $states.result.Payload.pushRequestObject.id %}",
-        "status": "{% $states.result.Payload.pushRequestObject.status %}",
-        "jobName": "{% $states.input.jobName %}",
-        "packageName": "{% $states.input.packageName %}",
-        "packageId": "{% $states.result.Payload.pushRequestObject.packageId %}",
-        "shareDestination": "{% $states.result.Payload.pushRequestObject.shareDestination %}",
-        "userId": "{% $states.input.userId %}",
-        "channelId": "{% $states.input.channelId %}",
-        "mainMessageTs": "{% $states.input.mainMessageTs %}",
-        "packageReadyMessageTs": "{% $states.input.packageReadyMessageTs %}"
+        "status": "{% $states.result.Payload.pushRequestObject.status %}"
       },
       "Retry": [
         {
@@ -219,15 +213,7 @@
       },
       "Output": {
         "id": "{% $states.input.id %}",
-        "status": "{% $states.result.Payload %}",
-        "jobName": "{% $states.input.jobName %}",
-        "packageName": "{% $states.input.packageName %}",
-        "packageId": "{% $states.input.packageId %}",
-        "shareDestination": "{% $states.input.shareDestination %}",
-        "userId": "{% $states.input.userId %}",
-        "channelId": "{% $states.input.channelId %}",
-        "mainMessageTs": "{% $states.input.mainMessageTs %}",
-        "packageReadyMessageTs": "{% $states.input.packageReadyMessageTs %}"
+        "status": "{% $states.result.Payload %}"
       },
       "Retry": [
         {
@@ -265,14 +251,14 @@
           "slackNotificationType": "PUSH_COMPLETED",
           "pushId": "{% $states.input.id %}",
           "status": "{% $states.input.status %}",
-          "packageName": "{% $states.input.packageName %}",
-          "packageId": "{% $states.input.packageId %}",
-          "shareDestination": "{% $states.input.shareDestination %}",
-          "userId": "{% $states.input.userId %}",
-          "channelId": "{% $states.input.channelId %}",
-          "jobName": "{% $states.input.jobName %}",
-          "mainMessageTs": "{% $states.input.mainMessageTs %}",
-          "packageReadyMessageTs": "{% $states.input.packageReadyMessageTs %}"
+          "packageName": "{% $packageName %}",
+          "packageId": "{% $packageId %}",
+          "shareDestination": "{% $shareDestination %}",
+          "userId": "{% $userId %}",
+          "channelId": "{% $channelId %}",
+          "jobName": "{% $jobName %}",
+          "mainMessageTs": "{% $mainMessageTs %}",
+          "packageReadyMessageTs": "{% $packageReadyMessageTs %}"
         }
       },
       "Retry": [

--- a/app/step-functions-templates/auto_push_sfn_template.asl.json
+++ b/app/step-functions-templates/auto_push_sfn_template.asl.json
@@ -213,7 +213,7 @@
       },
       "Output": {
         "id": "{% $states.input.id %}",
-        "status": "{% $states.result.Payload %}"
+        "status": "{% $states.result.Payload.status %}"
       },
       "Retry": [
         {

--- a/app/step-functions-templates/auto_push_sfn_template.asl.json
+++ b/app/step-functions-templates/auto_push_sfn_template.asl.json
@@ -74,11 +74,10 @@
         "shareDestination": "{% $states.result.Payload.shareDestination %}",
         "jobName": "{% $states.result.Payload.jobName %}",
         "packageReadyMessageTs": "{% $states.result.Payload.packageReadyMessageTs %}",
-        "mainMessageTs": "{% $states.result.Payload.mainMessageTs %}"
-      },
-      "Output": {
+        "mainMessageTs": "{% $states.result.Payload.mainMessageTs %}",
         "userAllowed": "{% $states.result.Payload.userAllowed %}"
       },
+      "Output": {},
       "Retry": [
         {
           "ErrorEquals": [
@@ -99,7 +98,7 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Condition": "{% $states.input.userAllowed = false %}",
+          "Condition": "{% $userAllowed = false %}",
           "Next": "Notify Slack: Push Not Authorised"
         }
       ],
@@ -177,10 +176,11 @@
           "shareDestination": "{% $shareDestination %}"
         }
       },
-      "Output": {
-        "id": "{% $states.result.Payload.pushRequestObject.id %}",
-        "status": "{% $states.result.Payload.pushRequestObject.status %}"
+      "Assign": {
+        "pushId": "{% $states.result.Payload.pushRequestObject.id %}",
+        "pushStatus": "{% $states.result.Payload.pushRequestObject.status %}"
       },
+      "Output": {},
       "Retry": [
         {
           "ErrorEquals": [
@@ -208,13 +208,13 @@
       "Arguments": {
         "FunctionName": "${__check_package_push_status_lambda_function_arn__}",
         "Payload": {
-          "id": "{% $states.input.id %}"
+          "id": "{% $pushId %}"
         }
       },
-      "Output": {
-        "id": "{% $states.input.id %}",
-        "status": "{% $states.result.Payload.status %}"
+      "Assign": {
+        "pushStatus": "{% $states.result.Payload.status %}"
       },
+      "Output": {},
       "Retry": [
         {
           "ErrorEquals": [
@@ -236,7 +236,7 @@
       "Choices": [
         {
           "Comment": "Push reached a terminal state: Succeeded, Failed, or Cancelled",
-          "Condition": "{% $states.input.status in [ 'SUCCEEDED', 'FAILED', 'CANCELLED' ] %}",
+          "Condition": "{% $pushStatus in [ 'SUCCEEDED', 'FAILED', 'CANCELLED' ] %}",
           "Next": "NotifySlack: Push Completed"
         }
       ],
@@ -249,8 +249,8 @@
         "FunctionName": "${__notify_slack_lambda_function_arn__}",
         "Payload": {
           "slackNotificationType": "PUSH_COMPLETED",
-          "pushId": "{% $states.input.id %}",
-          "status": "{% $states.input.status %}",
+          "pushId": "{% $pushId %}",
+          "pushStatus": "{% $pushStatus %}",
           "packageName": "{% $packageName %}",
           "packageId": "{% $packageId %}",
           "shareDestination": "{% $shareDestination %}",


### PR DESCRIPTION
This PR replaces `$states.input `pass-through chaining in the `autoPush` Step Functions with workflow scoped `Assign` variables. Slack context, push IDs, and push status are now assigned once and reused directly. Also standardises `check_package_push_status` to return a structured object and update `notify_slack` to the new `pushStatus` payload key.

